### PR TITLE
chore: update lume to lume-v0.1.34

### DIFF
--- a/Formula/lume.rb
+++ b/Formula/lume.rb
@@ -1,8 +1,8 @@
 class Lume < Formula
   desc "CLI and local API server to run macOS and Linux VMs on Apple Silicon"
   homepage "https://github.com/trycua"
-  url "https://github.com/trycua/lume/releases/download/v0.1.13/lume.tar.gz"
-  sha256 "e1d108aaaf12a65b9e20b5bd54d287fc526d49b40a0f2f5957bb8c2ff4f96691"
+  url "https://github.com/trycua/lume/releases/download/lume-v0.1.14/lume.tar.gz"
+  sha256 "95891f3373323a37aa76be66a2e01e13189c2c76d11debb9492c091e0de4951f"
   license "MIT"
 
   depends_on :macos


### PR DESCRIPTION
Updates to https://github.com/trycua/cua/releases/tag/lume-v0.1.34.